### PR TITLE
Fix Animated `useNativeDriver` required warnings

### DIFF
--- a/src/components/affix/index.js
+++ b/src/components/affix/index.js
@@ -51,6 +51,7 @@ export default class Affix extends PureComponent {
         .timing(opacity, {
           toValue: (props.active || props.focused)? 1 : 0,
           duration: animationDuration,
+          useNativeDriver: false
         })
         .start();
     }

--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -157,7 +157,7 @@ export default class TextField extends PureComponent {
       let toValue = this.focusState(props.error, state.focused);
 
       Animated
-        .timing(focus, { toValue, duration })
+        .timing(focus, { toValue, duration, useNativeDriver: false })
         .start(this.onFocusAnimationEnd);
     }
   }

--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -54,7 +54,7 @@ export default class Label extends PureComponent {
       let toValue = this.inputState(props);
 
       Animated
-        .timing(input, { toValue, duration })
+        .timing(input, { toValue, duration, useNativeDriver: false })
         .start();
     }
 
@@ -62,7 +62,7 @@ export default class Label extends PureComponent {
       let toValue = this.focusState(props);
 
       Animated
-        .timing(focus, { toValue, duration })
+        .timing(focus, { toValue, duration, useNativeDriver: false })
         .start();
     }
   }


### PR DESCRIPTION
This resolves warnings on RN 0.63.x related to `Animated` requiring `useNativeDriver` to be specified.

Unresolved upstream issue for reference: https://github.com/n4kz/react-native-material-textfield/issues/310